### PR TITLE
Add obs-fold header unfolding processor

### DIFF
--- a/src/neuralshield/preprocessing/config.toml
+++ b/src/neuralshield/preprocessing/config.toml
@@ -2,6 +2,7 @@
 order = [
   "neuralshield.preprocessing.steps.pre_parse_over_raw:RemoveFramingArtifacts",
   "neuralshield.preprocessing.steps.pre_parse_over_raw:RequestStructurer",
+  "neuralshield.preprocessing.steps.obs_fold_unfolder:ObsFoldUnfolder",
   "neuralshield.preprocessing.steps.flag_normalizer:FlagsNormalizer",
   "neuralshield.preprocessing.steps.query_processor:QueryProcessor",
   "neuralshield.preprocessing.steps.path_structure_normalizer:PathStructureNormalizer",

--- a/src/neuralshield/preprocessing/steps/obs_fold_unfolder.py
+++ b/src/neuralshield/preprocessing/steps/obs_fold_unfolder.py
@@ -1,0 +1,113 @@
+"""Header obs-fold unfolding processor.
+
+Implements the rules from specs/steps/lineas-plegadas-obs-fold.md to
+normalize obsolete header folding (obs-fold) by joining continuation lines,
+emitting flags for folded headers, and flagging malformed continuations.
+"""
+
+from __future__ import annotations
+
+from typing import List, Set
+
+from loguru import logger
+
+from neuralshield.preprocessing.http_preprocessor import HttpPreprocessor
+
+HEADER_PREFIX = "[HEADER] "
+CONTINUATION_PREFIXES = (" ", "\t")
+OBSFOLD_FLAG = "OBSFOLD"
+BADHDRCONT_FLAG = "BADHDRCONT"
+BADCRLF_FLAG = "BADCRLF"
+
+
+class ObsFoldUnfolder(HttpPreprocessor):
+    """Unfold obsolete header continuations (obs-fold)."""
+
+    def __init__(self) -> None:
+        # Stateless processor
+        pass
+
+    @staticmethod
+    def _sanitize_segment(segment: str) -> tuple[str, bool]:
+        """Replace embedded CR/LF characters with spaces.
+
+        Returns sanitized segment and whether CR/LF were removed.
+        """
+
+        if "\r" not in segment and "\n" not in segment:
+            return segment, False
+
+        logger.debug("Removing embedded CR/LF from header segment")
+        sanitized = segment.replace("\r", " ").replace("\n", " ")
+        return sanitized, True
+
+    @staticmethod
+    def _append_segment(current: str, segment: str) -> str:
+        """Join continuation segment ensuring a single space separator."""
+
+        base = current.rstrip(" \t")
+        if not segment:
+            return base
+        if not base:
+            return segment
+        return f"{base} {segment}"
+
+    def process(self, request: str) -> str:
+        """Process structured request and unfold header continuations."""
+
+        lines = request.strip().split("\n")
+        processed_lines: List[str] = []
+
+        current_header: str | None = None
+        current_flags: Set[str] = set()
+        badhdrcont_emitted = False
+
+        def flush_current() -> None:
+            nonlocal current_header, current_flags
+            if current_header is None:
+                return
+            final_content = current_header.rstrip(" \t")
+            processed_lines.append(f"{HEADER_PREFIX}{final_content}")
+            for flag in sorted(current_flags):
+                processed_lines.append(flag)
+            current_header = None
+            current_flags = set()
+
+        for raw_line in lines:
+            line = raw_line.strip()
+            if not line:
+                continue
+
+            if not line.startswith(HEADER_PREFIX):
+                flush_current()
+                processed_lines.append(line)
+                continue
+
+            header_content = line[len(HEADER_PREFIX) :]
+
+            if header_content.startswith(CONTINUATION_PREFIXES):
+                if current_header is None:
+                    if not badhdrcont_emitted:
+                        processed_lines.append(BADHDRCONT_FLAG)
+                        badhdrcont_emitted = True
+                    logger.debug("Observed header continuation without base header")
+                    continue
+
+                continuation = header_content.lstrip(" \t")
+                continuation, had_crlf = self._sanitize_segment(continuation)
+                if had_crlf:
+                    current_flags.add(BADCRLF_FLAG)
+                current_flags.add(OBSFOLD_FLAG)
+                current_header = self._append_segment(current_header, continuation)
+                continue
+
+            flush_current()
+            base_content, had_crlf = self._sanitize_segment(header_content)
+            current_header = base_content
+            current_flags = set()
+            if had_crlf:
+                current_flags.add(BADCRLF_FLAG)
+
+        flush_current()
+
+        return "\n".join(processed_lines)

--- a/src/neuralshield/preprocessing/test/in/111_obs_fold_bad_continuation.in
+++ b/src/neuralshield/preprocessing/test/in/111_obs_fold_bad_continuation.in
@@ -1,0 +1,4 @@
+GET /badfold HTTP/1.1
+  stray-start
+Host: example.com
+X-Test: ok

--- a/src/neuralshield/preprocessing/test/in/112_obs_fold_badcrlf.in
+++ b/src/neuralshield/preprocessing/test/in/112_obs_fold_badcrlf.in
@@ -1,0 +1,4 @@
+GET /crlf HTTP/1.1
+Host: example.com
+X-Evil: startInjected: bad
+X-Next: safe

--- a/src/neuralshield/preprocessing/test/out/001_basic_get.out
+++ b/src/neuralshield/preprocessing/test/out/001_basic_get.out
@@ -25,9 +25,8 @@ PAREN
 [HEADER] Accept: application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8
 [HEADER] Accept-Encoding: gzip, deflate, br
-[HEADER] X-Custom: first line
-[HEADER] 	second	part continued
-[HEADER]   third part
+[HEADER] X-Custom: first line second	part continued third part
+OBSFOLD
 [HEADER] X-Multi: αβγ
 [HEADER] X-Empty:
 [HEADER] Cache-Control: no-cache

--- a/src/neuralshield/preprocessing/test/out/002_root_no_query.out
+++ b/src/neuralshield/preprocessing/test/out/002_root_no_query.out
@@ -8,9 +8,8 @@ HOME
 [HEADER] X-Forwarded-For: 203.0.113.1, 70.41.3.18, 150.172.238.178
 [HEADER] Via: 1.1 vegur
 [HEADER] X-Request-Id: 123e4567-e89b-12d3-a456-426614174000
-[HEADER] X-Trace: start
-[HEADER] 	more
-[HEADER]   details
+[HEADER] X-Trace: start more details
+OBSFOLD
 [HEADER] If-None-Match: "abc123", "def456"
 QUOTE
 [HEADER] If-Modified-Since: Wed, 21 Oct 2015 07:28:00 GMT

--- a/src/neuralshield/preprocessing/test/out/003_duplicate_params.out
+++ b/src/neuralshield/preprocessing/test/out/003_duplicate_params.out
@@ -19,9 +19,8 @@
 [HEADER] Host: x.example
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8
 [HEADER] Cache-Control: max-age=0
-[HEADER] X-Header: value
-[HEADER] 	continued 1
-[HEADER]   continued 2
+[HEADER] X-Header: value continued 1 continued 2
+OBSFOLD
 [HEADER] X-Header: another
 [HEADER] X-Header: yet another
 [HEADER] Cookie: a=1; b=2; c=3

--- a/src/neuralshield/preprocessing/test/out/004_lowercase_and_continuations.out
+++ b/src/neuralshield/preprocessing/test/out/004_lowercase_and_continuations.out
@@ -5,14 +5,11 @@
 [QPARAM] y QREPEAT:y
 [QPARAM] z
 [QMETA] count=4 QEMPTYVAL
-[HEADER] host: x
-[HEADER] 	continued A
-[HEADER]   continued B
+[HEADER] host: x continued A continued B
+OBSFOLD
 [HEADER] User-Agent: TestAgent/1.0
-[HEADER] X-Obs: part1
-[HEADER] 	part2
-[HEADER] 		part3
-[HEADER]   part4
+[HEADER] X-Obs: part1 part2 part3 part4
+OBSFOLD
 [HEADER] Accept: */*
 [HEADER] Accept: application/json
 [HEADER] Foo: bar

--- a/src/neuralshield/preprocessing/test/out/111_obs_fold_bad_continuation.out
+++ b/src/neuralshield/preprocessing/test/out/111_obs_fold_bad_continuation.out
@@ -1,0 +1,5 @@
+[METHOD] GET
+[URL] /badfold
+BADHDRCONT
+[HEADER] Host: example.com
+[HEADER] X-Test: ok

--- a/src/neuralshield/preprocessing/test/out/112_obs_fold_badcrlf.out
+++ b/src/neuralshield/preprocessing/test/out/112_obs_fold_badcrlf.out
@@ -1,0 +1,6 @@
+[METHOD] GET
+[URL] /crlf
+[HEADER] Host: example.com
+[HEADER] X-Evil: start Injected: bad
+BADCRLF
+[HEADER] X-Next: safe

--- a/src/neuralshield/preprocessing/test/out/999_ultimate_comprehensive.out
+++ b/src/neuralshield/preprocessing/test/out/999_ultimate_comprehensive.out
@@ -30,14 +30,12 @@ DOTDOT MULTIPLESLASH
 MIXEDSCRIPT
 [HEADER] User-Agent: Mozilla/5.0 (Attack/1.0)
 PAREN
-[HEADER] X-Obs: part1
-[HEADER] 	continued A
-[HEADER]   continued B
+[HEADER] X-Obs: part1 continued A continued B
+OBSFOLD
 [HEADER] If-None-Match: "abc","def"
 QUOTE
-[HEADER] X-Custom: first line
-[HEADER] 	second	part continued
-[HEADER]   third part
+[HEADER] X-Custom: first line second	part continued third part
+OBSFOLD
 [HEADER] Authorization: Bearer ％74％6f％6b％65％6e
 [HEADER] Cookie: sid=abc123; theme=light
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8

--- a/src/neuralshield/preprocessing/test/result/001_basic_get.actual
+++ b/src/neuralshield/preprocessing/test/result/001_basic_get.actual
@@ -25,9 +25,8 @@ PAREN
 [HEADER] Accept: application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8
 [HEADER] Accept-Encoding: gzip, deflate, br
-[HEADER] X-Custom: first line
-[HEADER] 	second	part continued
-[HEADER]   third part
+[HEADER] X-Custom: first line second	part continued third part
+OBSFOLD
 [HEADER] X-Multi: αβγ
 [HEADER] X-Empty:
 [HEADER] Cache-Control: no-cache

--- a/src/neuralshield/preprocessing/test/result/002_root_no_query.actual
+++ b/src/neuralshield/preprocessing/test/result/002_root_no_query.actual
@@ -8,9 +8,8 @@ HOME
 [HEADER] X-Forwarded-For: 203.0.113.1, 70.41.3.18, 150.172.238.178
 [HEADER] Via: 1.1 vegur
 [HEADER] X-Request-Id: 123e4567-e89b-12d3-a456-426614174000
-[HEADER] X-Trace: start
-[HEADER] 	more
-[HEADER]   details
+[HEADER] X-Trace: start more details
+OBSFOLD
 [HEADER] If-None-Match: "abc123", "def456"
 QUOTE
 [HEADER] If-Modified-Since: Wed, 21 Oct 2015 07:28:00 GMT

--- a/src/neuralshield/preprocessing/test/result/003_duplicate_params.actual
+++ b/src/neuralshield/preprocessing/test/result/003_duplicate_params.actual
@@ -19,9 +19,8 @@
 [HEADER] Host: x.example
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8
 [HEADER] Cache-Control: max-age=0
-[HEADER] X-Header: value
-[HEADER] 	continued 1
-[HEADER]   continued 2
+[HEADER] X-Header: value continued 1 continued 2
+OBSFOLD
 [HEADER] X-Header: another
 [HEADER] X-Header: yet another
 [HEADER] Cookie: a=1; b=2; c=3

--- a/src/neuralshield/preprocessing/test/result/004_lowercase_and_continuations.actual
+++ b/src/neuralshield/preprocessing/test/result/004_lowercase_and_continuations.actual
@@ -5,14 +5,11 @@
 [QPARAM] y QREPEAT:y
 [QPARAM] z
 [QMETA] count=4 QEMPTYVAL
-[HEADER] host: x
-[HEADER] 	continued A
-[HEADER]   continued B
+[HEADER] host: x continued A continued B
+OBSFOLD
 [HEADER] User-Agent: TestAgent/1.0
-[HEADER] X-Obs: part1
-[HEADER] 	part2
-[HEADER] 		part3
-[HEADER]   part4
+[HEADER] X-Obs: part1 part2 part3 part4
+OBSFOLD
 [HEADER] Accept: */*
 [HEADER] Accept: application/json
 [HEADER] Foo: bar

--- a/src/neuralshield/preprocessing/test/result/111_obs_fold_bad_continuation.actual
+++ b/src/neuralshield/preprocessing/test/result/111_obs_fold_bad_continuation.actual
@@ -1,0 +1,5 @@
+[METHOD] GET
+[URL] /badfold
+BADHDRCONT
+[HEADER] Host: example.com
+[HEADER] X-Test: ok

--- a/src/neuralshield/preprocessing/test/result/112_obs_fold_badcrlf.actual
+++ b/src/neuralshield/preprocessing/test/result/112_obs_fold_badcrlf.actual
@@ -1,0 +1,6 @@
+[METHOD] GET
+[URL] /crlf
+[HEADER] Host: example.com
+[HEADER] X-Evil: start Injected: bad
+BADCRLF
+[HEADER] X-Next: safe

--- a/src/neuralshield/preprocessing/test/result/999_ultimate_comprehensive.actual
+++ b/src/neuralshield/preprocessing/test/result/999_ultimate_comprehensive.actual
@@ -30,14 +30,12 @@ DOTDOT MULTIPLESLASH
 MIXEDSCRIPT
 [HEADER] User-Agent: Mozilla/5.0 (Attack/1.0)
 PAREN
-[HEADER] X-Obs: part1
-[HEADER] 	continued A
-[HEADER]   continued B
+[HEADER] X-Obs: part1 continued A continued B
+OBSFOLD
 [HEADER] If-None-Match: "abc","def"
 QUOTE
-[HEADER] X-Custom: first line
-[HEADER] 	second	part continued
-[HEADER]   third part
+[HEADER] X-Custom: first line second	part continued third part
+OBSFOLD
 [HEADER] Authorization: Bearer ％74％6f％6b％65％6e
 [HEADER] Cookie: sid=abc123; theme=light
 [HEADER] Accept-Language: es-ES,es;q=0.9,en;q=0.8

--- a/src/neuralshield/preprocessing/test/test_pipeline.py
+++ b/src/neuralshield/preprocessing/test/test_pipeline.py
@@ -43,7 +43,8 @@ def run_tests() -> int:
         total += 1
         test_name = in_file.stem
 
-        raw_request = in_file.read_text(encoding="utf-8")
+        with in_file.open("r", encoding="utf-8", newline="") as handle:
+            raw_request = handle.read()
         actual = preprocess(raw_request)
 
         # Always write the generated processed request


### PR DESCRIPTION
## Summary
- introduce an ObsFoldUnfolder step that merges folded header continuations, emits OBSFOLD/BADCRLF/BADHDRCONT flags, and keeps sanitized values
- wire the new step into the preprocessing pipeline and update header-focused fixtures/actuals to reflect unfolded output
- extend the test harness to read requests with raw newlines and add coverage for orphan continuations and CRLF injections

## Testing
- uv run src/neuralshield/preprocessing/test/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68cf2907096c832690bf3c2b731a2630